### PR TITLE
Change permissions location to match docs

### DIFF
--- a/.github/workflows/bicep-validation.yaml
+++ b/.github/workflows/bicep-validation.yaml
@@ -10,13 +10,12 @@ on:
       - "infra/**"
   workflow_dispatch:
 
-permissions:
-  security-events: write
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,8 +27,6 @@ jobs:
           
       - name: Run Microsoft Security DevOps Analysis
         uses: microsoft/security-devops-action@v1
-        env:
-            GDN_TEMPLATEANALYZER_VERBOSE: 1
         id: msdo
         continue-on-error: true
         with:


### PR DESCRIPTION
## Purpose

Just reorg permissions to exactly match the docs at https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github
Also removed env variable so that it doesnt see the spurious errors. It seems to upload the issues fine without verbose mode needed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Wait for merge, trigger in actions