### PR TITLE
fix: pin langfuse image to version 2

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -113,7 +113,7 @@ module containerApp 'core/host/container-app.bicep' = {
     location: location
     tags: tags
     containerEnvId: containerAppEnv.outputs.id
-    imageName: 'ghcr.io/langfuse/langfuse:latest'
+    imageName: 'ghcr.io/langfuse/langfuse:2'
     targetPort: 3000
     env: [
       {


### PR DESCRIPTION
## What

@pamelafox: After creating our v3 milestone, we got the feedback that the Azure sample is breaking due to new mandatory environment variables. If we pin the image to `:2` that can be avoided until this sample starts to support v3.